### PR TITLE
Add a timeout for running extractors

### DIFF
--- a/configextractor/frameworks/base.py
+++ b/configextractor/frameworks/base.py
@@ -189,7 +189,7 @@ class Framework:
         """
         NotImplementedError()
 
-    def run(self, sample_path: str, parsers: Dict[Extractor, List[yara.Match]]) -> List[dict]:
+    def run(self, sample_path: str, parsers: Dict[Extractor, List[yara.Match]], timeout: int) -> List[dict]:
         """Run a series of modules.
 
         This function should specify how to run a series of modules on a sample under the framework
@@ -197,6 +197,7 @@ class Framework:
         Args:
           sample_path (str): Path to the sample to run the modules on
           parsers (Dict[Extractor, List[yara.Match]]): Extractor modules and their YARA matches
+          timeout (int): How long to wait for each module to complete
 
         Returns:
           (List[dict]): List of results from the modules

--- a/configextractor/main.py
+++ b/configextractor/main.py
@@ -224,12 +224,13 @@ class ConfigExtractor:
                     if value:
                         network_conn[part] = value
 
-    def run_parsers(self, sample: str, parser_blocklist: List[str] = []) -> Dict[str, List[dict]]:
+    def run_parsers(self, sample: str, parser_blocklist: List[str] = [], timeout: int = 30) -> Dict[str, List[dict]]:
         """Run parsers on a sample.
 
         Args:
           sample (str): Path to the sample to run the parsers on
           parser_blocklist (List[str]): List of regex patterns to block parsers. Defaults to [].
+          timeout (int): How long to wait for each parser to complete. Defaults to 30 seconds.
 
         Returns:
             (Dict[str, List[dict]]): Results from the parsers across different frameworks
@@ -275,7 +276,7 @@ class ConfigExtractor:
                         f"Running the following under the {framework} framework with YARA: "
                         + f"{[p.id for p in parser_list]}"
                     )
-                    result = self.FRAMEWORK_LIBRARY_MAPPING[framework].run(sample_copy.name, parser_list)
+                    result = self.FRAMEWORK_LIBRARY_MAPPING[framework].run(sample_copy.name, parser_list, timeout)
                     self.finalize(result)
                     if result:
                         results[framework] = result


### PR DESCRIPTION
This is help prevent task pre-emption in automated tools like Assemblyline.

At the very least, if a particular extractor is taking long to run, we can still get the results from extractors that did complete their analysis before the timeout was reached.